### PR TITLE
remove cfg-if and bump edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,10 @@
 [package]
 name = "system_error"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jeremy Larkin <jeremylarkin@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/kalamay/system_error"
 documentation = "https://docs.rs/system_error"
 description = "A library for cross platform system errors"
-keywords = ["error", "system_error", "kern_return_t"]
-edition = "2018"
-
-[dependencies]
-cfg-if = "0.1.10"
+keywords = ["error", "system_error", "kern_return_t", "mach"]
+edition = "2021"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //! ```
 //! # if cfg!(target_os = "linux") {
 //! use system_error::Error;
-//! use std::io;
+//! use std::io::ErrorKind;
 //!
 //! let os_error = Error::from_raw_os_error(1);
-//! assert_eq!(os_error.kind(), io::ErrorKind::PermissionDenied);
+//! assert_eq!(os_error.kind(), ErrorKind::PermissionDenied);
 //! assert_eq!(
 //!     format!("{}", os_error),
 //!     "Operation not permitted (os error 1)"
@@ -25,7 +25,7 @@
 //! );
 //!
 //! let kern_error = Error::from_raw_kernel_error(8);
-//! assert_eq!(kern_error.kind(), io::ErrorKind::Other);
+//! assert_eq!(kern_error.kind(), ErrorKind::Other);
 //! assert_eq!(
 //!     format!("{}", kern_error),
 //!     "Unknown error (kernel error 8)"
@@ -42,10 +42,10 @@
 //! ```
 //! # if cfg!(target_os = "macos") {
 //! use system_error::Error;
-//! use std::io;
+//! use std::io::ErrorKind;
 //!
 //! let os_error = Error::from_raw_os_error(1);
-//! assert_eq!(os_error.kind(), io::ErrorKind::PermissionDenied);
+//! assert_eq!(os_error.kind(), ErrorKind::PermissionDenied);
 //! assert_eq!(
 //!     format!("{}", os_error),
 //!     "Operation not permitted (os error 1)"
@@ -56,7 +56,7 @@
 //! );
 //!
 //! let kern_error = Error::from_raw_kernel_error(8);
-//! assert_eq!(kern_error.kind(), io::ErrorKind::PermissionDenied);
+//! assert_eq!(kern_error.kind(), ErrorKind::PermissionDenied);
 //! assert_eq!(
 //!     format!("{}", kern_error),
 //!     "(os/kern) no access (kernel error 8)"
@@ -73,10 +73,10 @@
 //! ```
 //! # if cfg!(windows) {
 //! use system_error::Error;
-//! use std::io;
+//! use std::io::ErrorKind;
 //!
 //! let os_error = Error::from_raw_os_error(5);
-//! assert_eq!(os_error.kind(), io::ErrorKind::PermissionDenied);
+//! assert_eq!(os_error.kind(), ErrorKind::PermissionDenied);
 //! assert_eq!(
 //!     format!("{}", os_error),
 //!     "Access is denied. (os error 5)"
@@ -87,7 +87,7 @@
 //! );
 //!
 //! let kern_error = Error::from_raw_kernel_error(8);
-//! assert_eq!(kern_error.kind(), io::ErrorKind::Other);
+//! assert_eq!(kern_error.kind(), ErrorKind::Other);
 //! assert_eq!(
 //!     format!("{}", kern_error),
 //!     "Unknown error (kernel error 8)"
@@ -101,6 +101,7 @@
 
 use std::convert::TryFrom;
 use std::os::raw::c_int;
+use std::str::Utf8Error;
 use std::{error, fmt, io};
 
 /// An error type for cross platform system-level errors.
@@ -218,11 +219,12 @@ impl Error {
     /// # Examples
     ///
     /// ```
+    /// # if cfg!(not(target_os = "windows")) {
     /// use system_error::Error;
     /// use std::io;
     ///
-    /// assert_eq!(Error::last_os_error().kind(), io::ErrorKind::Other);
     /// assert_eq!(Error::from_raw_os_error(1).kind(), io::ErrorKind::PermissionDenied);
+    /// # }
     /// ```
     pub fn kind(&self) -> io::ErrorKind {
         match self.0 {
@@ -364,10 +366,153 @@ impl KernelError {
     }
 }
 
-impl error::Error for KernelError {}
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+impl KernelError {
+    /// Converts the `KernelCode` into the most appropriate message `str`.
+    pub fn to_str(&self) -> Result<&str, Utf8Error> {
+        Ok("Unknown error")
+    }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+    /// Converts the `KernelCode` into the most appropriate `std::io::ErrorKind`.
+    pub fn kind(&self) -> io::ErrorKind {
+        io::ErrorKind::Other
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+impl KernelError {
+    /// The operation succeeded.
+    pub const KERN_SUCCESS: KernelCode = 0;
+    /// Specified address is not currently valid.
+    pub const KERN_INVALID_ADDRESS: KernelCode = 1;
+    /// Specified memory is valid, but does not permit the required
+    /// forms of access.
+    pub const KERN_PROTECTION_FAILURE: KernelCode = 2;
+    /// The address range specified is already in use, or no address
+    /// range of the size specified could be found.
+    pub const KERN_NO_SPACE: KernelCode = 3;
+    /// The function requested was not applicable to this type of argument,
+    /// or an argument is invalid
+    pub const KERN_INVALID_ARGUMENT: KernelCode = 4;
+    /// The function could not be performed. A catch-all.
+    pub const KERN_FAILURE: KernelCode = 5;
+    /// A system resource could not be allocated to fulfill this request.
+    /// This failure may not be permanent.
+    pub const KERN_RESOURCE_SHORTAGE: KernelCode = 6;
+    /// The task in question does not hold receive rights for the port argument.
+    pub const KERN_NOT_RECEIVER: KernelCode = 7;
+    /// Bogus access restriction.
+    pub const KERN_NO_ACCESS: KernelCode = 8;
+    /// During a page fault, the target address refers to a memory object
+    /// that has been destroyed. This failure is permanent.
+    pub const KERN_MEMORY_FAILURE: KernelCode = 9;
+    /// During a page fault, the memory object indicated that the data could
+    /// not be returned. This failure may be temporary; future attempts to
+    /// access this same data may succeed, as defined by the memory object.
+    pub const KERN_MEMORY_ERROR: KernelCode = 10;
+    /// The receive right is already a member of the portset.
+    pub const KERN_ALREADY_IN_SET: KernelCode = 11;
+    /// The receive right is not a member of a port set.
+    pub const KERN_NOT_IN_SET: KernelCode = 12;
+    /// The name already denotes a right in the task.
+    pub const KERN_NAME_EXISTS: KernelCode = 13;
+    /// The operation was aborted. Ipc code will catch this and reflect it as
+    /// a message error.
+    pub const KERN_ABORTED: KernelCode = 14;
+    /// The name doesn't denote a right in the task.
+    pub const KERN_INVALID_NAME: KernelCode = 15;
+    /// Target task isn't an active task.
+    pub const KERN_INVALID_TASK: KernelCode = 16;
+    /// The name denotes a right, but not an appropriate right.
+    pub const KERN_INVALID_RIGHT: KernelCode = 17;
+    /// A blatant range error.
+    pub const KERN_INVALID_VALUE: KernelCode = 18;
+    /// Operation would overflow limit on user-references.
+    pub const KERN_UREFS_OVERFLOW: KernelCode = 19;
+    /// The supplied (port) capability is improper.
+    pub const KERN_INVALID_CAPABILITY: KernelCode = 20;
+    /// The task already has send or receive rights for the port under another name.
+    pub const KERN_RIGHT_EXISTS: KernelCode = 21;
+    /// Target host isn't actually a host.
+    pub const KERN_INVALID_HOST: KernelCode = 22;
+    /// An attempt was made to supply "precious" data for memory that is
+    /// already present in a memory object.
+    pub const KERN_MEMORY_PRESENT: KernelCode = 23;
+    /// A page was requested of a memory manager via memory_object_data_request
+    /// for an object using a MEMORY_OBJECT_COPY_CALL strategy, with the
+    /// VM_PROT_WANTS_COPY flag being used to specify that the page desired is
+    /// for a copy of the object, and the memory manager has detected the page
+    /// was pushed into a copy of the object while the kernel was walking the
+    /// shadow chain from the copy to the object. This error code is delivered
+    /// via memory_object_data_error and is handled by the kernel (it forces
+    /// the kernel to restart the fault). It will not be seen by users.
+    pub const KERN_MEMORY_DATA_MOVED: KernelCode = 24;
+    /// A strategic copy was attempted of an object upon which a quicker copy is
+    /// now possible. The caller should retry the copy using vm_object_copy_quickly.
+    /// This error code is seen only by the kernel.
+    pub const KERN_MEMORY_RESTART_COPY: KernelCode = 25;
+    /// An argument applied to assert processor set privilege was not a
+    /// processor set control port.
+    pub const KERN_INVALID_PROCESSOR_SET: KernelCode = 26;
+    /// The specified scheduling attributes exceed the thread's limits.
+    pub const KERN_POLICY_LIMIT: KernelCode = 27;
+    /// The specified scheduling policy is not currently enabled for the processor set.
+    pub const KERN_INVALID_POLICY: KernelCode = 28;
+    /// The external memory manager failed to initialize the memory object.
+    pub const KERN_INVALID_OBJECT: KernelCode = 29;
+    /// A thread is attempting to wait for an event for which there is
+    /// already a waiting thread.
+    pub const KERN_ALREADY_WAITING: KernelCode = 30;
+    /// An attempt was made to destroy the default processor set.
+    pub const KERN_DEFAULT_SET: KernelCode = 31;
+    /// An attempt was made to fetch an exception port that is protected,
+    /// or to abort a thread while processing a protected exception.
+    pub const KERN_EXCEPTION_PROTECTED: KernelCode = 32;
+    /// A ledger was required but not supplied.
+    pub const KERN_INVALID_LEDGER: KernelCode = 33;
+    /// The port was not a memory cache control port.
+    pub const KERN_INVALID_MEMORY_CONTROL: KernelCode = 34;
+    /// An argument supplied to assert security privilege was not a host security port.
+    pub const KERN_INVALID_SECURITY: KernelCode = 35;
+    /// thread_depress_abort was called on a thread which was not currently depressed.
+    pub const KERN_NOT_DEPRESSED: KernelCode = 36;
+    /// Object has been terminated and is no longer available
+    pub const KERN_TERMINATED: KernelCode = 37;
+    /// Lock set has been destroyed and is no longer available.
+    pub const KERN_LOCK_SET_DESTROYED: KernelCode = 38;
+    /// The thread holding the lock terminated before releasing the lock
+    pub const KERN_LOCK_UNSTABLE: KernelCode = 39;
+    /// The lock is already owned by another thread
+    pub const KERN_LOCK_OWNED: KernelCode = 40;
+    /// The lock is already owned by the calling thread
+    pub const KERN_LOCK_OWNED_SELF: KernelCode = 41;
+    /// Semaphore has been destroyed and is no longer available.
+    pub const KERN_SEMAPHORE_DESTROYED: KernelCode = 42;
+    /// Return from RPC indicating the target server was terminated before
+    /// it successfully replied
+    pub const KERN_RPC_SERVER_TERMINATED: KernelCode = 43;
+    /// Terminate an orphaned activation.
+    pub const KERN_RPC_TERMINATE_ORPHAN: KernelCode = 44;
+    /// Allow an orphaned activation to continue executing.
+    pub const KERN_RPC_CONTINUE_ORPHAN: KernelCode = 45;
+    /// Empty thread activation (No thread linked to it)
+    pub const KERN_NOT_SUPPORTED: KernelCode = 46;
+    /// Remote node down or inaccessible.
+    pub const KERN_NODE_DOWN: KernelCode = 47;
+    /// A signalled thread was not actually waiting.
+    pub const KERN_NOT_WAITING: KernelCode = 48;
+    /// Some thread-oriented operation (semaphore_wait) timed out
+    pub const KERN_OPERATION_TIMED_OUT: KernelCode = 49;
+    /// During a page fault, indicates that the page was rejected as a
+    /// result of a signature check.
+    pub const KERN_CODESIGN_ERROR: KernelCode = 50;
+    /// The requested property cannot be changed at this time.
+    pub const KERN_POLICY_STATIC: KernelCode = 51;
+    /// The provided buffer is of insufficient size for the requested data.
+    pub const KERN_INSUFFICIENT_BUFFER_SIZE: KernelCode = 52;
+
+    /// Converts the `KernelCode` into the most appropriate message `str`.
+    pub fn to_str(&self) -> Result<&str, Utf8Error> {
         use std::ffi::CStr;
         use std::os::raw::c_char;
 
@@ -375,242 +520,85 @@ cfg_if::cfg_if! {
             fn mach_error_string(code: KernelCode) -> *const c_char;
         }
 
-        impl fmt::Debug for KernelError {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let msg = unsafe { CStr::from_ptr(mach_error_string(self.0)) };
-                fmt.debug_struct("KernelError")
-                    .field("code", &self.0)
-                    .field("message", &msg.to_str().unwrap_or("invalid kernel error"))
-                    .finish()
+        unsafe { CStr::from_ptr(mach_error_string(self.0)) }.to_str()
+    }
+
+    /// Converts the `KernelCode` into the most appropriate `std::io::ErrorKind`.
+    pub fn kind(&self) -> io::ErrorKind {
+        match self.0 {
+            Self::KERN_PROTECTION_FAILURE
+            | Self::KERN_NO_ACCESS
+            | Self::KERN_NOT_RECEIVER
+            | Self::KERN_EXCEPTION_PROTECTED => io::ErrorKind::PermissionDenied,
+
+            Self::KERN_RPC_SERVER_TERMINATED | Self::KERN_RPC_TERMINATE_ORPHAN => {
+                io::ErrorKind::ConnectionAborted
             }
+
+            Self::KERN_NAME_EXISTS
+            | Self::KERN_RIGHT_EXISTS
+            | Self::KERN_MEMORY_PRESENT
+            | Self::KERN_ALREADY_WAITING => io::ErrorKind::AlreadyExists,
+
+            Self::KERN_INVALID_ADDRESS
+            | Self::KERN_INVALID_ARGUMENT
+            | Self::KERN_INVALID_CAPABILITY
+            | Self::KERN_INVALID_HOST
+            | Self::KERN_INVALID_LEDGER
+            | Self::KERN_INVALID_MEMORY_CONTROL
+            | Self::KERN_INVALID_NAME
+            | Self::KERN_INVALID_OBJECT
+            | Self::KERN_INVALID_POLICY
+            | Self::KERN_INVALID_PROCESSOR_SET
+            | Self::KERN_INVALID_RIGHT
+            | Self::KERN_INVALID_SECURITY
+            | Self::KERN_INVALID_TASK
+            | Self::KERN_INVALID_VALUE
+            | Self::KERN_NO_SPACE
+            | Self::KERN_MEMORY_FAILURE
+            | Self::KERN_ALREADY_IN_SET
+            | Self::KERN_NOT_IN_SET
+            | Self::KERN_DEFAULT_SET
+            | Self::KERN_NOT_DEPRESSED
+            | Self::KERN_UREFS_OVERFLOW
+            | Self::KERN_POLICY_LIMIT
+            | Self::KERN_LOCK_SET_DESTROYED
+            | Self::KERN_LOCK_UNSTABLE
+            | Self::KERN_LOCK_OWNED
+            | Self::KERN_LOCK_OWNED_SELF
+            | Self::KERN_SEMAPHORE_DESTROYED
+            | Self::KERN_NOT_SUPPORTED
+            | Self::KERN_NOT_WAITING
+            | Self::KERN_INSUFFICIENT_BUFFER_SIZE => io::ErrorKind::InvalidInput,
+
+            Self::KERN_MEMORY_ERROR
+            | Self::KERN_NODE_DOWN
+            | Self::KERN_CODESIGN_ERROR
+            | Self::KERN_POLICY_STATIC => io::ErrorKind::InvalidData,
+
+            Self::KERN_OPERATION_TIMED_OUT => io::ErrorKind::TimedOut,
+
+            _ => io::ErrorKind::Other,
         }
+    }
+}
 
-        impl fmt::Display for KernelError {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                let msg = unsafe { CStr::from_ptr(mach_error_string(self.0)) };
-                match msg.to_str() {
-                    Err(err) => write!(fmt, "invalid kernel error {} ({})", self.0, err),
-                    Ok(val) => write!(fmt, "{} (kernel error {})", val, self.0),
-                }
-            }
-        }
+impl error::Error for KernelError {}
 
-        impl KernelError {
-            /// Converts the `KernelCode` into the most appropriate `std::io::ErrorKind`.
-            pub fn kind(&self) -> io::ErrorKind {
-                match self.0 {
-                    KERN_PROTECTION_FAILURE
-                    | KERN_NO_ACCESS
-                    | KERN_NOT_RECEIVER
-                    | KERN_EXCEPTION_PROTECTED
-                    => io::ErrorKind::PermissionDenied,
+impl fmt::Debug for KernelError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("KernelError")
+            .field("code", &self.0)
+            .field("message", &self.to_str().unwrap_or("invalid kernel error"))
+            .finish()
+    }
+}
 
-
-                    KERN_RPC_SERVER_TERMINATED
-                    | KERN_RPC_TERMINATE_ORPHAN
-                    => io::ErrorKind::ConnectionAborted,
-
-                    KERN_NAME_EXISTS
-                    | KERN_RIGHT_EXISTS
-                    | KERN_MEMORY_PRESENT
-                    | KERN_ALREADY_WAITING
-                    => io::ErrorKind::AlreadyExists,
-
-                    KERN_INVALID_ADDRESS
-                    | KERN_INVALID_ARGUMENT
-                    | KERN_INVALID_CAPABILITY
-                    | KERN_INVALID_HOST
-                    | KERN_INVALID_LEDGER
-                    | KERN_INVALID_MEMORY_CONTROL
-                    | KERN_INVALID_NAME
-                    | KERN_INVALID_OBJECT
-                    | KERN_INVALID_POLICY
-                    | KERN_INVALID_PROCESSOR_SET
-                    | KERN_INVALID_RIGHT
-                    | KERN_INVALID_SECURITY
-                    | KERN_INVALID_TASK
-                    | KERN_INVALID_VALUE
-                    | KERN_NO_SPACE
-                    | KERN_MEMORY_FAILURE
-                    | KERN_ALREADY_IN_SET
-                    | KERN_NOT_IN_SET
-                    | KERN_DEFAULT_SET
-                    | KERN_NOT_DEPRESSED
-                    | KERN_UREFS_OVERFLOW
-                    | KERN_POLICY_LIMIT
-                    | KERN_LOCK_SET_DESTROYED
-                    | KERN_LOCK_UNSTABLE
-                    | KERN_LOCK_OWNED
-                    | KERN_LOCK_OWNED_SELF
-                    | KERN_SEMAPHORE_DESTROYED
-                    | KERN_NOT_SUPPORTED
-                    | KERN_NOT_WAITING
-                    | KERN_INSUFFICIENT_BUFFER_SIZE
-                    => io::ErrorKind::InvalidInput,
-
-                    KERN_MEMORY_ERROR
-                    | KERN_NODE_DOWN
-                    | KERN_CODESIGN_ERROR
-                    | KERN_POLICY_STATIC
-                    => io::ErrorKind::InvalidData,
-
-                    KERN_OPERATION_TIMED_OUT
-                    => io::ErrorKind::TimedOut,
-
-                    _ => io::ErrorKind::Other,
-                }
-            }
-        }
-
-        /// The operation succeeded.
-        pub const KERN_SUCCESS: KernelCode = 0;
-        /// Specified address is not currently valid.
-        pub const KERN_INVALID_ADDRESS: KernelCode = 1;
-        /// Specified memory is valid, but does not permit the required
-        /// forms of access.
-        pub const KERN_PROTECTION_FAILURE: KernelCode = 2;
-        /// The address range specified is already in use, or no address
-        /// range of the size specified could be found.
-        pub const KERN_NO_SPACE: KernelCode = 3;
-        /// The function requested was not applicable to this type of argument,
-        /// or an argument is invalid
-        pub const KERN_INVALID_ARGUMENT: KernelCode = 4;
-        /// The function could not be performed. A catch-all.
-        pub const KERN_FAILURE: KernelCode = 5;
-        /// A system resource could not be allocated to fulfill this request.
-        /// This failure may not be permanent.
-        pub const KERN_RESOURCE_SHORTAGE: KernelCode = 6;
-        /// The task in question does not hold receive rights for the port argument.
-        pub const KERN_NOT_RECEIVER: KernelCode = 7;
-        /// Bogus access restriction.
-        pub const KERN_NO_ACCESS: KernelCode = 8;
-        /// During a page fault, the target address refers to a memory object
-        /// that has been destroyed. This failure is permanent.
-        pub const KERN_MEMORY_FAILURE: KernelCode = 9;
-        /// During a page fault, the memory object indicated that the data could
-        /// not be returned. This failure may be temporary; future attempts to
-        /// access this same data may succeed, as defined by the memory object.
-        pub const KERN_MEMORY_ERROR: KernelCode = 10;
-        /// The receive right is already a member of the portset.
-        pub const KERN_ALREADY_IN_SET: KernelCode = 11;
-        /// The receive right is not a member of a port set.
-        pub const KERN_NOT_IN_SET: KernelCode = 12;
-        /// The name already denotes a right in the task.
-        pub const KERN_NAME_EXISTS: KernelCode = 13;
-        /// The operation was aborted. Ipc code will catch this and reflect it as
-        /// a message error.
-        pub const KERN_ABORTED: KernelCode = 14;
-        /// The name doesn't denote a right in the task.
-        pub const KERN_INVALID_NAME: KernelCode = 15;
-        /// Target task isn't an active task.
-        pub const KERN_INVALID_TASK: KernelCode = 16;
-        /// The name denotes a right, but not an appropriate right.
-        pub const KERN_INVALID_RIGHT: KernelCode = 17;
-        /// A blatant range error.
-        pub const KERN_INVALID_VALUE: KernelCode = 18;
-        /// Operation would overflow limit on user-references.
-        pub const KERN_UREFS_OVERFLOW: KernelCode = 19;
-        /// The supplied (port) capability is improper.
-        pub const KERN_INVALID_CAPABILITY: KernelCode = 20;
-        /// The task already has send or receive rights for the port under another name.
-        pub const KERN_RIGHT_EXISTS: KernelCode = 21;
-        /// Target host isn't actually a host.
-        pub const KERN_INVALID_HOST: KernelCode = 22;
-        /// An attempt was made to supply "precious" data for memory that is
-        /// already present in a memory object.
-        pub const KERN_MEMORY_PRESENT: KernelCode = 23;
-        /// A page was requested of a memory manager via memory_object_data_request
-        /// for an object using a MEMORY_OBJECT_COPY_CALL strategy, with the
-        /// VM_PROT_WANTS_COPY flag being used to specify that the page desired is
-        /// for a copy of the object, and the memory manager has detected the page
-        /// was pushed into a copy of the object while the kernel was walking the
-        /// shadow chain from the copy to the object. This error code is delivered
-        /// via memory_object_data_error and is handled by the kernel (it forces
-        /// the kernel to restart the fault). It will not be seen by users.
-        pub const KERN_MEMORY_DATA_MOVED: KernelCode = 24;
-        /// A strategic copy was attempted of an object upon which a quicker copy is
-        /// now possible. The caller should retry the copy using vm_object_copy_quickly.
-        /// This error code is seen only by the kernel.
-        pub const KERN_MEMORY_RESTART_COPY: KernelCode = 25;
-        /// An argument applied to assert processor set privilege was not a
-        /// processor set control port.
-        pub const KERN_INVALID_PROCESSOR_SET: KernelCode = 26;
-        /// The specified scheduling attributes exceed the thread's limits.
-        pub const KERN_POLICY_LIMIT: KernelCode = 27;
-        /// The specified scheduling policy is not currently enabled for the processor set.
-        pub const KERN_INVALID_POLICY: KernelCode = 28;
-        /// The external memory manager failed to initialize the memory object.
-        pub const KERN_INVALID_OBJECT: KernelCode = 29;
-        /// A thread is attempting to wait for an event for which there is
-        /// already a waiting thread.
-        pub const KERN_ALREADY_WAITING: KernelCode = 30;
-        /// An attempt was made to destroy the default processor set.
-        pub const KERN_DEFAULT_SET: KernelCode = 31;
-        /// An attempt was made to fetch an exception port that is protected,
-        /// or to abort a thread while processing a protected exception.
-        pub const KERN_EXCEPTION_PROTECTED: KernelCode = 32;
-        /// A ledger was required but not supplied.
-        pub const KERN_INVALID_LEDGER: KernelCode = 33;
-        /// The port was not a memory cache control port.
-        pub const KERN_INVALID_MEMORY_CONTROL: KernelCode = 34;
-        /// An argument supplied to assert security privilege was not a host security port.
-        pub const KERN_INVALID_SECURITY: KernelCode = 35;
-        /// thread_depress_abort was called on a thread which was not currently depressed.
-        pub const KERN_NOT_DEPRESSED: KernelCode = 36;
-        /// Object has been terminated and is no longer available
-        pub const KERN_TERMINATED: KernelCode = 37;
-        /// Lock set has been destroyed and is no longer available.
-        pub const KERN_LOCK_SET_DESTROYED: KernelCode = 38;
-        /// The thread holding the lock terminated before releasing the lock
-        pub const KERN_LOCK_UNSTABLE: KernelCode = 39;
-        /// The lock is already owned by another thread
-        pub const KERN_LOCK_OWNED: KernelCode = 40;
-        /// The lock is already owned by the calling thread
-        pub const KERN_LOCK_OWNED_SELF: KernelCode = 41;
-        /// Semaphore has been destroyed and is no longer available.
-        pub const KERN_SEMAPHORE_DESTROYED: KernelCode = 42;
-        /// Return from RPC indicating the target server was terminated before
-        /// it successfully replied
-        pub const KERN_RPC_SERVER_TERMINATED: KernelCode = 43;
-        /// Terminate an orphaned activation.
-        pub const KERN_RPC_TERMINATE_ORPHAN: KernelCode = 44;
-        /// Allow an orphaned activation to continue executing.
-        pub const KERN_RPC_CONTINUE_ORPHAN: KernelCode = 45;
-        /// Empty thread activation (No thread linked to it)
-        pub const KERN_NOT_SUPPORTED: KernelCode = 46;
-        /// Remote node down or inaccessible.
-        pub const KERN_NODE_DOWN: KernelCode = 47;
-        /// A signalled thread was not actually waiting.
-        pub const KERN_NOT_WAITING: KernelCode = 48;
-        /// Some thread-oriented operation (semaphore_wait) timed out
-        pub const KERN_OPERATION_TIMED_OUT: KernelCode = 49;
-        /// During a page fault, indicates that the page was rejected as a
-        /// result of a signature check.
-        pub const KERN_CODESIGN_ERROR: KernelCode = 50;
-        /// The requested property cannot be changed at this time.
-        pub const KERN_POLICY_STATIC: KernelCode = 51;
-        /// The provided buffer is of insufficient size for the requested data.
-        pub const KERN_INSUFFICIENT_BUFFER_SIZE: KernelCode = 52;
-    } else {
-        impl fmt::Debug for KernelError {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt.debug_struct("KernelError")
-                    .field("code", &self.0)
-                    .field("message", &"Unknown error")
-                    .finish()
-            }
-        }
-
-        impl fmt::Display for KernelError {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(fmt, "Unknown error (kernel error {})", self.0)
-            }
-        }
-
-        impl KernelError {
-            pub fn kind(&self) -> io::ErrorKind {
-                io::ErrorKind::Other
-            }
+impl fmt::Display for KernelError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.to_str() {
+            Err(err) => write!(fmt, "invalid kernel error {} ({})", self.0, err),
+            Ok(val) => write!(fmt, "{} (kernel error {})", val, self.0),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,9 +337,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl Into<io::Error> for Error {
-    fn into(self) -> io::Error {
-        match self.0 {
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        match err.0 {
             Type::Os(code) => io::Error::from_raw_os_error(code),
             Type::Kernel(code) => {
                 let err = KernelError::new(code);


### PR DESCRIPTION
This removes the `cfg-if` dependency and bumps the rust edition to 2021.